### PR TITLE
Fix Path/Range sometimes breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.2](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.1...v1.0.2)
+
+### Fixed
+- Generic searches (non-search related params) no longer accepted, raise 400
+
+------
 ## [1.0.1](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.0...v1.0.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Generic searches (non-search related params) no longer accepted, raise 400
+- Fixed string comparison of numbers in range filters
 
 ------
 ## [1.0.1](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.0...v1.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Generic searches (non-search related params) no longer accepted, raise 400
 - Fixed string comparison of numbers in range filters
 
+### Changed
+- Include wkt in error when raising in `validate_wkt()`
+
 ------
 ## [1.0.1](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.0...v1.0.1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ watchfiles==0.19.0
 asf_search==8.2.3
 python-json-logger==2.0.7
 
-pyshp
+pyshp==2.1.3
 geopandas
 geomet
 kml2geojson

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -222,7 +222,7 @@ def validate_wkt(wkt: str):
         wrapped, unwrapped, reports = asf.validate_wkt(wkt)
         repairs = [{'type': report.report_type, 'report': report.report} for report in reports if report.report_type != "'type': 'WRAP'"]
     except Exception as exc:
-        raise HTTPException(detail=f"Failed to validate wkt: {exc}", status_code=400) from exc
+        raise HTTPException(detail=f"Failed to validate wkt {wkt}: {exc}", status_code=400) from exc
 
     return {
         'wkt': {

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -42,6 +42,17 @@ async def query_params(searchOptions: SearchOptsModel = Depends(process_search_r
     output = searchOptions.output
     opts = searchOptions.opts
 
+    non_search_param = ['output', 'maxresults', 'pagesize', 'maturity']
+    try:
+        any_searchables = any([key.lower() not in non_search_param for key, _ in opts])
+        if not any_searchables:
+            raise ValueError(
+                'No searchable parameters specified, queries must include'
+                ' parameters besides output= and maxresults='
+            )
+    except ValueError as exc:
+        raise HTTPException(detail=repr(exc), status_code=400) from exc
+
     if output.lower() == 'count':
         start = time.perf_counter()
         count=asf.search_count(opts=opts)

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -13,6 +13,7 @@ from .asf_env import load_config_maturity
 
 from .logger import api_logger
 
+non_search_param = ['output', 'maxresults', 'pagesize', 'maturity']
 
 def string_to_range(v: Union[str, list]) -> tuple:
     if isinstance(v, list):
@@ -161,6 +162,16 @@ async def process_search_request(request: Request) -> SearchOptsModel:
     body_opts = get_asf_opts(body)
 
     query_opts.merge_args(**dict(body_opts))
+
+    try:
+        any_searchables = any([key.lower() not in non_search_param for key, _ in query_opts])
+        if not any_searchables:
+            raise ValueError(
+                'No searchable parameters specified, queries must include'
+                ' parameters besides output= and maxresults='
+            )
+    except ValueError as exc:
+        raise HTTPException(detail=repr(exc), status_code=400) from exc
 
     merged_args = {**query_params, **body}
 

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -23,7 +23,7 @@ def string_to_range(v: Union[str, list]) -> tuple:
         if m is None:
             raise ValueError(f'Invalid range: {v}')
         a = (m.group(1), m.group(3))
-        if int(a[0]) > int(a[1]):
+        if float(a[0]) > float(a[1]):
             raise ValueError()
         if a[0] == a[1]:
             a = a[0]

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -23,7 +23,7 @@ def string_to_range(v: Union[str, list]) -> tuple:
         if m is None:
             raise ValueError(f'Invalid range: {v}')
         a = (m.group(1), m.group(3))
-        if a[0] > a[1]:
+        if int(a[0]) > int(a[1]):
             raise ValueError()
         if a[0] == a[1]:
             a = a[0]

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -163,16 +163,6 @@ async def process_search_request(request: Request) -> SearchOptsModel:
 
     query_opts.merge_args(**dict(body_opts))
 
-    try:
-        any_searchables = any([key.lower() not in non_search_param for key, _ in query_opts])
-        if not any_searchables:
-            raise ValueError(
-                'No searchable parameters specified, queries must include'
-                ' parameters besides output= and maxresults='
-            )
-    except ValueError as exc:
-        raise HTTPException(detail=repr(exc), status_code=400) from exc
-
     merged_args = {**query_params, **body}
 
     if (token := merged_args.get('cmr_token')):


### PR DESCRIPTION
### Fixed
- Generic searches (non-search related params) no longer accepted, raise 400
- Fixed string comparison of numbers in range filters

### Changed
- Include wkt in error when raising in `validate_wkt()` - fixes string comparison of numbers in range filters