### PR TITLE
More NISAR dataset collections, `session` omitted from `python` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.2](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.1...v1.0.2)
+
+### Fixed
+- Omit `session` in `python` output
+
+------
 ## [1.0.1](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.0...v1.0.1)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Omit `session` in `python` output
 
+### Changed
+- bump asf-search to 8.3.4 for latest `NISAR` collections
+
 ------
 ## [1.0.1](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.0...v1.0.1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf_search==8.3.3
+asf_search==8.3.4
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/src/SearchAPI/application/output.py
+++ b/src/SearchAPI/application/output.py
@@ -167,6 +167,7 @@ def get_asf_search_script(
         search_endpoint: Literal['param', 'baseline'] = 'param'
         ) -> tuple[str, str]:
     
+    opts.session = None
     if search_endpoint == 'param':
         file_name=make_filename('py', prefix='asf-search-script')
         output_script = asf_search_script_template.format(file_name, str(opts))


### PR DESCRIPTION
## [1.0.2](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.1...v1.0.2)

### Fixed
- Omit `session` in `python` output

### Changed
- bump asf-search to 8.3.4 for latest `NISAR` collections