### PR TITLE
Patch Release 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.6](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.5...v1.0.6)
+### Changed
+- bump asf-search to v9.0.7
+
+------
 ## [1.0.5](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.4...v1.0.5)
 ### Added
 - Added `json` output format support

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf_search==9.0.6
+asf_search==9.0.7
 python-json-logger==2.0.7
 asf_enumeration
 


### PR DESCRIPTION
## [1.0.6](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.5...v1.0.6)
### Changed
- bump asf-search to v9.0.7