### PR TITLE
Patch Release v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.10](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.9...v1.0.10)
+### Changed
+- bump asf-search to v10.2.0
+    - new SEASAT dataset collection
+    - NISAR concept-id + collection names in jsonlite outputs
+    - L0B science product now only contains RRSD
+
+------
 ## [1.0.9](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.8...v1.0.9)
 ### Fixed
 - Fixed bug with ARIA-S1 GUNW stacking over areas without pre-existing ARIA-S1-Frames

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==10.1.2
+asf-search[asf-enumeration]==10.2.0
 python-json-logger==2.0.7
 
 pyshp==2.1.3


### PR DESCRIPTION
## [1.0.10](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.9...v1.0.10)
### Changed
- bump asf-search to v10.2.0
    - new SEASAT dataset collection
    - NISAR concept-id + collection names in jsonlite outputs
    - L0B science product now only contains RRSD