### PR TITLE
Patch Release 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.11](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.10...v1.0.11)
+### Changed
+- bump asf-search to v11.0.1
+    - NISAR CRID field
+    - NISAR track number searchable with relativeOrbit, parsed from UMM
+    - remove `nisar_stuf` collection from NISAR dataset collections list (further removals pending)
+
+------
 ## [1.0.10](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.9...v1.0.10)
 ### Changed
 - bump asf-search to v10.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==10.2.0
+asf-search[asf-enumeration]==11.0.1
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from copy import copy
 import json
 
@@ -225,6 +226,26 @@ async def file_to_wkt(files: list[UploadFile]):
         status_code=200,
         headers=constants.DEFAULT_HEADERS
     )
+
+@router.get('/services/utils/kml_footprint')
+async def kml_to_footprint(request: Request, granule: str, maturity: str = 'prod'):
+    config = load_config_maturity(maturity=maturity)
+
+    query_opts = asf.ASFSearchOptions(granule_list=[granule])
+    if (auth:=request.headers.get('authorization')) is not None:
+        session = SearchAPISession()
+        session.headers.update({'Authorization': auth})
+        query_opts.session = session
+
+
+    query_opts.host = config['cmr_base']
+
+    results = asf.search(opts=query_opts, dataset=asf.DATASET.NISAR)
+
+    kml_file = results.find_urls(extension='.kml')[0]
+    
+    kml_response = query_opts.session.get(kml_file)
+    return kml_response.text
 
 # example: https://api.daac.asf.alaska.edu/services/redirect/NISAR_L2_STATIC/{granule_id}.h5
 # @router.get('/services/redirect/{short_name}/{granule_id}')

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -228,13 +228,13 @@ async def file_to_wkt(files: list[UploadFile]):
     )
 
 @router.get('/services/utils/kml_footprint')
-async def kml_to_footprint(request: Request, granule: str, maturity: str = 'prod'):
+async def kml_to_footprint(granule: str, cmr_token: Optional[str] = None, maturity: str = 'prod'):
     config = load_config_maturity(maturity=maturity)
 
     query_opts = asf.ASFSearchOptions(granule_list=[granule])
-    if (auth:=request.headers.get('authorization')) is not None:
+    if (cmr_token) is not None:
         session = SearchAPISession()
-        session.headers.update({'Authorization': auth})
+        session.headers.update({'Authorization': f'Bearer {cmr_token}'})
         query_opts.session = session
 
 

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -245,7 +245,12 @@ async def kml_to_footprint(granule: str, cmr_token: Optional[str] = None, maturi
     kml_file = results.find_urls(extension='.kml')[0]
     
     kml_response = query_opts.session.get(kml_file)
-    return kml_response.text.strip('"')
+    return Response(
+        content=str(kml_response.text),
+        status_code=200,
+        media_type='text/html; charset=utf-8',
+        headers=constants.DEFAULT_HEADERS
+    )
 
 # example: https://api.daac.asf.alaska.edu/services/redirect/NISAR_L2_STATIC/{granule_id}.h5
 # @router.get('/services/redirect/{short_name}/{granule_id}')

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -245,7 +245,7 @@ async def kml_to_footprint(granule: str, cmr_token: Optional[str] = None, maturi
     kml_file = results.find_urls(extension='.kml')[0]
     
     kml_response = query_opts.session.get(kml_file)
-    return kml_response.text
+    return kml_response.text.strip('"')
 
 # example: https://api.daac.asf.alaska.edu/services/redirect/NISAR_L2_STATIC/{granule_id}.h5
 # @router.get('/services/redirect/{short_name}/{granule_id}')

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -167,7 +167,7 @@ async def process_search_request(request: Request, is_baseline: bool = False) ->
 
     if (token := merged_args.get('cmr_token')):
         session = SearchAPISession()
-        session.headers.update({'Authorization': request.headers.get('Authorization')})
+        session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
         query_opts.session = session
 
     output = merged_args.get('output', 'metalink')

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -167,7 +167,7 @@ async def process_search_request(request: Request, is_baseline: bool = False) ->
 
     if (token := merged_args.get('cmr_token')):
         session = SearchAPISession()
-        session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
+        session.headers.update({'Authorization': request.headers.get('Authorization')})
         query_opts.session = session
 
     output = merged_args.get('output', 'metalink')

--- a/tests/yml_tests/test_URLs.yml
+++ b/tests/yml_tests/test_URLs.yml
@@ -192,7 +192,7 @@ tests:
 
 - beamMode STD SS 100:
     beamMode: STD
-    platform: SEASAT
+    platform: "SEASAT 1"
     maxresults: 100
     output: csv
 
@@ -468,9 +468,9 @@ tests:
 
 - groupid S1 Insar:
     groupid: S1-GUNW-D-R-087-tops-20190816_20190804-161614-19149N_17138N-PP-fee7-v2_0_2
-    output: blank json
+    output: json
 
-    expected file: json
+    expected file: blank json
     expected code: 200
 
 - groupid SMAP:
@@ -2391,7 +2391,7 @@ tests:
 - start end 6monthago:
     start: 6+month+ago
     end: now
-    dataset: SENTINEL-1A
+    dataset: SENTINEL-1
     maxResults: 10
     output: csv
 
@@ -2430,7 +2430,7 @@ tests:
 - start backwards reversed:
     start: now
     end: 1+year+ago
-    dataset: SENTINEL-1A
+    dataset: SENTINEL-1
     output: csv
     maxResults: 10
 
@@ -2440,7 +2440,7 @@ tests:
 - start tomorrow reversed:
     start: tomorrow
     end: 1+year+ago
-    dataset: SENTINEL-1A
+    dataset: SENTINEL-1
     output: csv
     maxResults: 10
 

--- a/tests/yml_tests/test_URLs.yml
+++ b/tests/yml_tests/test_URLs.yml
@@ -190,8 +190,8 @@ tests:
     expected file: csv
     expected code: 200
 
-- beamSwath STD SS 100:
-    beamSwath: STD
+- beamMode STD SS 100:
+    beamMode: STD
     platform: SEASAT
     maxresults: 100
     output: csv
@@ -468,7 +468,7 @@ tests:
 
 - groupid S1 Insar:
     groupid: S1-GUNW-D-R-087-tops-20190816_20190804-161614-19149N_17138N-PP-fee7-v2_0_2
-    output: json
+    output: blank json
 
     expected file: json
     expected code: 200
@@ -2042,15 +2042,6 @@ tests:
     expected file: csv
     expected code: 200
 
-- processingLevel SEASAT:
-    processingLevel: L1,BROWSE,THUMBNAIL
-    platform: SEASAT
-    maxResults: 10
-    output: csv
-
-    expected file: csv
-    expected code: 200
-
 - processingLevel S1:
     processingLevel: METADATA_GRD,GRD_HS,GRD_HD,GRD_MS,GRD_MD,GRD_FS,GRD_FD,SLC,RAW,OCN,METADATA_RAW,METADATA,METADATA_SLC, THUMBNAIL
     platform: Sentinel-1A,Sentinel-1B
@@ -2400,6 +2391,7 @@ tests:
 - start end 6monthago:
     start: 6+month+ago
     end: now
+    dataset: SENTINEL-1A
     maxResults: 10
     output: csv
 
@@ -2438,6 +2430,7 @@ tests:
 - start backwards reversed:
     start: now
     end: 1+year+ago
+    dataset: SENTINEL-1A
     output: csv
     maxResults: 10
 
@@ -2447,6 +2440,7 @@ tests:
 - start tomorrow reversed:
     start: tomorrow
     end: 1+year+ago
+    dataset: SENTINEL-1A
     output: csv
     maxResults: 10
 


### PR DESCRIPTION
## [1.0.11](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.10...v1.0.11)
### Changed
- bump asf-search to v11.0.1
    - NISAR CRID field
    - NISAR track number searchable with relativeOrbit, parsed from UMM
    - remove `nisar_stuf` collection from NISAR dataset collections list (further removals pending)