### PR TITLE
Patch Release v1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
+### Changed
+- bump asf-search to v11.0.2
+    - ARIA-S1 GUNW 2.0.3 byteSize and product type display support
+
+------
 ## [1.0.11](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.10...v1.0.11)
 ### Changed
 - bump asf-search to v11.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==11.0.1
+asf-search[asf-enumeration]==11.0.2
 python-json-logger==2.0.7
 
 pyshp==2.1.3


### PR DESCRIPTION
## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
### Changed
- bump asf-search to v11.0.2
    - ARIA-S1 GUNW 2.0.3 byteSize and product type display support

