### PR TITLE
Patch Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - bump asf-search to v11.0.2
     - ARIA-S1 GUNW 2.0.3 byteSize and product type display support
-
+    - NISAR dateline RRSD products now properly parsed from UMM, merged into single polygon
 ### fixed
 - allow setting `cmr_provider` on granule/product list searches
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
 ### Changed
-- bump asf-search to v11.0.2
+- bump asf-search to v11.0.3
     - ARIA-S1 GUNW 2.0.3 byteSize and product type display support
     - NISAR dateline RRSD products now properly parsed from UMM, merged into single polygon
 ### fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - bump asf-search to v11.0.2
     - ARIA-S1 GUNW 2.0.3 byteSize and product type display support
 
+### fixed
+- allow setting `cmr_provider` on granule/product list searches
+
 ------
 ## [1.0.11](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.10...v1.0.11)
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==11.0.2
+asf-search[asf-enumeration]==11.0.3
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -169,6 +169,9 @@ async def process_search_request(request: Request, is_baseline: bool = False) ->
         session = SearchAPISession()
         session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
         query_opts.session = session
+    
+    if (cmr_provider := merged_args.get('cmr_provider')):
+        query_opts.provider=cmr_provider
 
     output = merged_args.get('output', 'metalink')
     maturity = merged_args.get('maturity', 'prod')
@@ -269,7 +272,7 @@ def get_asf_opts(params: dict) -> asf.ASFSearchOptions:
 
     # SearchOpts doesn't know how to handle these keys, but other methods need them
     # (We still want to throw on any UNKNOWN keys)
-    ignore_keys_lower = ["output", "reference", "maturity", "cmr_keywords", "cmr_token"]
+    ignore_keys_lower = ["output", "reference", "maturity", "cmr_keywords", "cmr_token", "cmr_provider"]
     params = {k: params[k] for k in params.keys() if k.lower() not in ignore_keys_lower}
 
     try:


### PR DESCRIPTION
### changed
- bump asf-search to v11.0.3
    - ARIA-S1 GUNW 2.0.3 byteSize and product type display support
    - NISAR dateline RRSD products now properly parsed from UMM, merged into single polygon
### fixed
- allow setting `cmr_provider` on granule/product list searches