### PR TITLE
feat: add gzip compression middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
     - Added `ECMWF_TROPO` to `TROPO` dataset
     - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset
-
+- Add gzip compression middleware
 ------
 ## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
 ### Changed

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -9,6 +9,7 @@ import asf_search as asf
 from fastapi import Depends, FastAPI, Request, HTTPException, APIRouter, UploadFile
 from fastapi.responses import Response, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 from .log_router import LoggingRoute
 from .logger import api_logger
@@ -36,6 +37,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
+
 
 cfg = load_config_maturity()
 cmr_health = get_cmr_health(cfg['cmr_base'], cfg['cmr_health'])


### PR DESCRIPTION

## Purpose
API gateway throws an error for requests for responses with size greater than 10MB. NISAR results, specifically searching for the vertex option of 1000 products at once increases the response size to 8.8MB, not including the API gateway extras that get added on, this makes API gateway throw a 502 error. 


## Description
Browsers can negotiate compression techniques automatically, we just need to set it up for FastAPI using the [GZIP middleware](https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware). This PR adds that middleware to our API.

This process is better described in the [Mozilla docs about compression](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression)

