### PR TITLE
Patch Release V1.0.13

### DIFF
--- a/.github/workflows/search-api-composite/action.yml
+++ b/.github/workflows/search-api-composite/action.yml
@@ -52,6 +52,7 @@ runs:
       run: |
         cd cdk
         cdk cli-telemetry --disable
+        cdk acknowledge 34892
         cdk deploy --require-approval=never \
           --context vpc_id=${{ inputs.vpc-id }} \
           --context subnet_ids=${{ inputs.subnet-ids }} \

--- a/.github/workflows/search-api-composite/action.yml
+++ b/.github/workflows/search-api-composite/action.yml
@@ -47,11 +47,11 @@ runs:
         python -m pip install -r cdk/requirements.txt
         npm install -g aws-cdk
 
-      
     - name: Deploy to AWS
       shell: bash
       run: |
         cd cdk
+        cdk cli-telemetry --disable
         cdk deploy --require-approval=never \
           --context vpc_id=${{ inputs.vpc-id }} \
           --context subnet_ids=${{ inputs.subnet-ids }} \

--- a/.github/workflows/search-api-composite/action.yml
+++ b/.github/workflows/search-api-composite/action.yml
@@ -47,7 +47,11 @@ runs:
         python -m pip install -r cdk/requirements.txt
         npm install -g aws-cdk
 
-      
+    - name: Set CDK Environment Variables
+      shell: bash
+      run: |
+        echo "CDK_DISABLE_CLI_TELEMETRY=true" >> $GITHUB_ENV
+
     - name: Deploy to AWS
       shell: bash
       run: |

--- a/.github/workflows/search-api-composite/action.yml
+++ b/.github/workflows/search-api-composite/action.yml
@@ -47,11 +47,7 @@ runs:
         python -m pip install -r cdk/requirements.txt
         npm install -g aws-cdk
 
-    - name: Set CDK Environment Variables
-      shell: bash
-      run: |
-        echo "CDK_DISABLE_CLI_TELEMETRY=true" >> $GITHUB_ENV
-
+      
     - name: Deploy to AWS
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
     - Added `ECMWF_TROPO` to `TROPO` dataset
     - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset
-
+- Add gzip compression middleware
 ------
 ## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [1.0.13](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.12...v1.0.13)
 ### Changed
-- bump asf-search to v12.0.0
+- bump asf-search to v12.0.1
     - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
     - Added `ECMWF_TROPO` to `TROPO` dataset
     - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.13](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.12...v1.0.13)
+### Changed
+- bump asf-search to v12.0.0
+    - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
+    - Added `ECMWF_TROPO` to `TROPO` dataset
+    - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset
+
+------
 ## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
 ### Changed
 - bump asf-search to v11.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [1.0.13](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.12...v1.0.13)
 ### Changed
-- bump asf-search to v12.0.1
+- bump asf-search to v12.0.2
     - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
-    - Added `ECMWF_TROPO` to `TROPO` dataset
+    - Added `ECMWF_TROP` to `TROPO` dataset
     - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset
 - Add gzip compression middleware
+
 ------
 ## [1.0.12](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.11...v1.0.12)
 ### Changed

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -15,6 +15,7 @@
     ]
   },
   "context": {
+    "cli-telemetry": false,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -15,7 +15,6 @@
     ]
   },
   "context": {
-    "cli-telemetry": false,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.149.0
+aws-cdk-lib==2.238.0
 constructs>=10.0.0,<11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==12.0.0
+asf-search[asf-enumeration]==12.0.1
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==12.0.1
+asf-search[asf-enumeration]==12.0.2
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==11.0.3
+asf-search[asf-enumeration]==12.0.0
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -9,6 +9,7 @@ import asf_search as asf
 from fastapi import Depends, FastAPI, Request, HTTPException, APIRouter, UploadFile
 from fastapi.responses import Response, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 from .log_router import LoggingRoute
 from .logger import api_logger
@@ -36,6 +37,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
+
 
 cfg = load_config_maturity()
 cmr_health = get_cmr_health(cfg['cmr_base'], cfg['cmr_health'])


### PR DESCRIPTION
## [1.0.13](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.12...v1.0.13)
### Changed
- bump asf-search to v12.0.2
    - `TROPO-ZENITH` moved from `OPERA-S1` to new `TROPO` dataset
    - Added `ECMWF_TROP` to `TROPO` dataset
    - Add `DISP-S1-STATIC` product type to `OPERA-S1` dataset
- Add gzip compression middleware
