### PR TITLE
feat: `ariaVersion` searchable, `orbitType` available in jsonlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.14](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.13...v1.0.14)
+### Changed
+- bump asf-search to v12.0.3
+    - `ariaVersion` searchable attribute
+    - `orbitType` parsed for `NISARProduct`, available in jsonlite output
+
+------
 ## [1.0.13](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.12...v1.0.13)
 ### Changed
 - bump asf-search to v12.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==12.0.2
+asf-search[asf-enumeration]==12.0.3
 python-json-logger==2.0.7
 
 pyshp==2.1.3


### PR DESCRIPTION
------
## [1.0.14](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.13...v1.0.14)
### Changed
- bump asf-search to v12.0.3
    - `ariaVersion` searchable attribute
    - `orbitType` parsed for `NISARProduct`, available in jsonlite output

