### PR TITLE
Patch Release v1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [1.0.15](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.14...v1.0.15)
+### Changed
+- bump asf-search to v12.0.5
+    - DIST-ALERT-S1 product type to OPERA dataset
+        - TileID searchable attribute
+        - productVersion attribute
+    - Fix edge-case with `platform` & `processingLevel` concept-id aliasing
+    - Updated `NISAR` dataset/platform concept-ids
+
+------
 ## [1.0.14](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.13...v1.0.14)
 ### Changed
 - bump asf-search to v12.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,17 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [1.0.15](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.14...v1.0.15)
 ### Changed
-- bump asf-search to v12.0.5
+- bump asf-search to v12.0.6
     - DIST-ALERT-S1 product type to OPERA dataset
         - TileID searchable attribute
         - productVersion attribute
     - Fix edge-case with `platform` & `processingLevel` concept-id aliasing
     - Updated `NISAR` dataset/platform concept-ids
+    - `utils.NISAR.get_nisar_orbit_ephemera()` method
+    - NISAR `track` and `frame` fix when specifying science product type
+
+### Added
+- Adds `services/utils/nisar_orbit_ephemera` endpoint, returns ordered list of latest NISAR orbit ephemera of POE, MOE, NOE, and FOE products
 
 ------
 ## [1.0.14](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.13...v1.0.14)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==12.0.3
+asf-search[asf-enumeration]==12.0.5
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ujson==5.7.0
 uvicorn==0.21.1
 watchfiles==0.19.0
 
-asf-search[asf-enumeration]==12.0.5
+asf-search[asf-enumeration]==12.0.6
 python-json-logger==2.0.7
 
 pyshp==2.1.3

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -260,10 +260,16 @@ async def kml_to_footprint(granule: str, cmr_token: Optional[str] = None, maturi
 @router.get('/services/utils/nisar_orbit_ephemera')
 async def get_nisar_orbit_ephemera():
     """Returns the latest nisar orbit ephemera products for POE, MOE, NOE, and FOE in that order. Returns as jsonlite2"""
-    oe_dict = asf.utils.get_nisar_orbit_ephemeras()
-    results = ASFSearchResults([product for product in oe_dict.values()])
-    response_info = as_output(results, 'jsonlite2')
-    return Response(**response_info)
+    try:
+        oe_dict = asf.utils.get_nisar_orbit_ephemeras()
+        results = ASFSearchResults([product for product in oe_dict.values()])
+        response_info = as_output(results, 'jsonlite2')
+        return Response(**response_info)
+    except (asf.ASFSearchError, asf.CMRError, ValueError) as exc:
+        raise HTTPException(
+            detail=f"Search failed to find results: {exc}",
+            status_code=400
+        ) from exc
 
 # example: https://api.daac.asf.alaska.edu/services/redirect/NISAR_L2_STATIC/{granule_id}.h5
 # @router.get('/services/redirect/{short_name}/{granule_id}')

--- a/src/SearchAPI/application/application.py
+++ b/src/SearchAPI/application/application.py
@@ -22,6 +22,7 @@ from .files_to_wkt import FilesToWKT
 from . import constants
 from .SearchAPISession import SearchAPISession
 from asf_search.ASFSearchOptions.config import config as asf_config
+from asf_search import ASFSearchResults
 from asf_enumeration import aria_s1_gunw
 
 asf_config['session'] = SearchAPISession()
@@ -255,6 +256,14 @@ async def kml_to_footprint(granule: str, cmr_token: Optional[str] = None, maturi
         media_type='text/html; charset=utf-8',
         headers=constants.DEFAULT_HEADERS
     )
+
+@router.get('/services/utils/nisar_orbit_ephemera')
+async def get_nisar_orbit_ephemera():
+    """Returns the latest nisar orbit ephemera products for POE, MOE, NOE, and FOE in that order. Returns as jsonlite2"""
+    oe_dict = asf.utils.get_nisar_orbit_ephemeras()
+    results = ASFSearchResults([product for product in oe_dict.values()])
+    response_info = as_output(results, 'jsonlite2')
+    return Response(**response_info)
 
 # example: https://api.daac.asf.alaska.edu/services/redirect/NISAR_L2_STATIC/{granule_id}.h5
 # @router.get('/services/redirect/{short_name}/{granule_id}')


### PR DESCRIPTION
## [1.0.15](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.14...v1.0.15)
### Changed
- bump asf-search to v12.0.5
    - DIST-ALERT-S1 product type to OPERA dataset
        - TileID searchable attribute
        - productVersion attribute
    - Fix edge-case with `platform` & `processingLevel` concept-id aliasing
    - Updated `NISAR` dataset/platform concept-ids