### PR TITLE
feat: granule list supports other filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -
 
 -->
+-----
+## [1.0.17](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.15...v1.0.16)
+### Changed
+- Searches with `granule_list` can use other search filters
+
 ------
 ## [1.0.16](https://github.com/asfadmin/Discovery-SearchAPI-v3/compare/v1.0.15...v1.0.16)
 ### Changed

--- a/src/SearchAPI/application/asf_opts.py
+++ b/src/SearchAPI/application/asf_opts.py
@@ -295,10 +295,6 @@ def get_asf_opts(params: dict) -> asf.ASFSearchOptions:
                         "Unbound wildcard searches not supported with SearchAPI."
                         "Specify `maxresults` or use the asf-search python module directly (try `output=python` to download the equivalent script)"
                     )
-            if len([param for param in params if param not in ["collections", "maxResults"]]) > 1:
-                raise ValueError(
-                    'Cannot use search keywords "granule_list/product_list" with other search params'
-                )
 
         if (flight_direction := params.get("flightDirection")) is not None:
             if isinstance(flight_direction, str) and len(flight_direction):


### PR DESCRIPTION
## Changes
 - Enables searches that use filters to combine `granule_list` with other filters. For use with the granule wildcard in dataset searches in Vertex.